### PR TITLE
Add settings flag to allow for disabling re-positioning of HUD messages

### DIFF
--- a/AlternateConversationCamera.rc
+++ b/AlternateConversationCamera.rc
@@ -1,0 +1,100 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 2,4,5,0
+ PRODUCTVERSION 2,4,5,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x2L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "TODO: <Company name>"
+            VALUE "FileDescription", "TODO: <File description>"
+            VALUE "FileVersion", "2.4.5.0"
+            VALUE "InternalName", "Alternat.dll"
+            VALUE "LegalCopyright", "Copyright (C) 2020"
+            VALUE "OriginalFilename", "Alternat.dll"
+            VALUE "ProductName", "TODO: <Product name>"
+            VALUE "ProductVersion", "2.4.5.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/AlternateConversationCamera.rc
+++ b/AlternateConversationCamera.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,4,5,0
- PRODUCTVERSION 2,4,5,0
+ FILEVERSION 2,4,6,0
+ PRODUCTVERSION 2,4,6,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "TODO: <Company name>"
             VALUE "FileDescription", "TODO: <File description>"
-            VALUE "FileVersion", "2.4.5.0"
+            VALUE "FileVersion", "2.4.6.0"
             VALUE "InternalName", "Alternat.dll"
             VALUE "LegalCopyright", "Copyright (C) 2020"
             VALUE "OriginalFilename", "Alternat.dll"
             VALUE "ProductName", "TODO: <Product name>"
-            VALUE "ProductVersion", "2.4.5.0"
+            VALUE "ProductVersion", "2.4.6.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/AlternateConversationCamera.vcxproj
+++ b/AlternateConversationCamera.vcxproj
@@ -176,6 +176,7 @@
     <ClInclude Include="Menus.h" />
     <ClInclude Include="ObjectRef.h" />
     <ClInclude Include="PatternScanner.h" />
+    <ClInclude Include="resource.h" />
     <ClInclude Include="ScaleformUtils.h" />
     <ClInclude Include="Settings.h" />
     <ClInclude Include="Shader.h" />
@@ -194,6 +195,9 @@
     <ProjectReference Include="skse64_common\skse64_common.vcxproj">
       <Project>{5fd1c08d-db80-480c-a1c6-f0920005cd13}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="AlternateConversationCamera.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/AlternateConversationCamera.vcxproj.filters
+++ b/AlternateConversationCamera.vcxproj.filters
@@ -80,10 +80,18 @@
     <ClInclude Include="Havok.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="exports.def">
       <Filter>Source Files</Filter>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="AlternateConversationCamera.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/Camera.cpp
+++ b/Camera.cpp
@@ -2,6 +2,7 @@
 #include "ObjectRef.h"
 #include "skse64/NiNodes.h"
 
+
 namespace Tralala
 {
 	uintptr_t g_playerCameraAddr = 0;
@@ -15,6 +16,7 @@ namespace Tralala
 	uintptr_t g_processCamColAddr = 0;
 	uintptr_t g_getClosestPointAddr = 0;
 	uintptr_t g_camProcessColAddr = 0;
+
 
 	void PlayerCameraGetAddress()
 	{
@@ -42,14 +44,13 @@ namespace Tralala
 		g_camProcessColAddr = (uintptr_t)scan_memory_data(processColPattern, 0xBF, false, 0x1, 0x5);
 	}
 
+
 	float ThirdPersonState::GetDistanceWithinTargetHead(Actor * target)
 	{
-		if (!target || !target->processManager || !target->processManager->middleProcess)
-			return FLT_MAX;
+		if (!target || !target->processManager || !target->processManager->middleProcess) return FLT_MAX;
 
 		NiNode* headNode = (NiNode*)target->processManager->middleProcess->unk158;
-		if (!headNode)
-			return FLT_MAX;
+		if (!headNode) return FLT_MAX;
 
 		NiPoint3 dist;
 		dist.x = camPos.x - headNode->m_worldTransform.pos.x;
@@ -58,6 +59,7 @@ namespace Tralala
 
 		return (dist.x*dist.x + dist.y*dist.y + dist.z*dist.z);
 	}
+
 
 	void ThirdPersonState::SetFirstPersonSmooth(float minZoom, bool overShoulder)
 	{
@@ -72,9 +74,9 @@ namespace Tralala
 			curPosY = dstPosY;
 		}
 
-		if (!overShoulder)
-			fOverShoulderPosX = fOverShoulderCombatAddY = fOverShoulderPosZ = 0.0f;
+		if (!overShoulder) fOverShoulderPosX = fOverShoulderCombatAddY = fOverShoulderPosZ = 0.0f;
 	}
+
 
 	void ThirdPersonState::SetShoulderPos(const NiPoint3& pos)
 	{
@@ -83,21 +85,22 @@ namespace Tralala
 		this->fOverShoulderCombatAddY = pos.y;
 	}
 
+
 	void ThirdPersonState::ProcessCameraCollision()
 	{
 		typedef void(*ProcessCamCol_t)(ThirdPersonState*);
 		ProcessCamCol_t ProcessCamCol = (ProcessCamCol_t)g_processCamColAddr;
-
 		ProcessCamCol(this);
 	}
+
 
 	void TESCamera::SetCameraState(TESCameraState * camState)
 	{
 		typedef UInt32(*SetCameraState_t)(TESCamera* camera, TESCameraState* cameraState);
 		SetCameraState_t SetCameraState = (SetCameraState_t)g_setCameraStateAddr;
-
 		SetCameraState(this, camState);
 	}
+
 
 	NiCamera* TESCamera::GetNiCamera()
 	{
@@ -106,33 +109,35 @@ namespace Tralala
 		for (std::size_t i = 0; i < size; ++i)
 		{
 			NiAVObject* pObj = cameraNode->m_children.m_data[i];
-			if (!pObj)
-				continue;
+			if (!pObj) continue;
 
 			if (strcmp(pObj->GetRTTI()->name, "NiCamera") == 0) 
 			{
 				camera = (NiCamera*)pObj;
 				break;
 			}
-
 		}
 		return camera;
 	}
+
 
 	PlayerCamera * PlayerCamera::GetSingleton()
 	{
 		return *(PlayerCamera**)g_playerCameraAddr;
 	}
 
+
 	bool PlayerCamera::IsCameraFirstPerson()
 	{
 		return cameraState == cameraStates[kCameraState_FirstPerson];
 	}
 
+
 	bool PlayerCamera::IsCameraThirdPerson()
 	{
 		return cameraState == cameraStates[kCameraState_ThirdPerson2];
 	}
+
 
 	TESCameraState * PlayerCamera::ProcessCameraTransition(UInt32 srcCamState, UInt32 dstCamState, bool face2face)
 	{
@@ -143,7 +148,6 @@ namespace Tralala
 		{
 			typedef SInt32(*PushTargetCamState_t)(Data40 * data40, TESCameraState * camState);
 			PushTargetCamState_t PushTargetCamState = (PushTargetCamState_t)g_pushTargetCamAddr;
-
 			PushTargetCamState(&unk40, target);
 		}
 		else
@@ -167,57 +171,54 @@ namespace Tralala
 		return target;
 	}
 
+
 	void PlayerCamera::SetCameraTarget(Actor* target)
 	{
 		typedef void(*SetCameraTarget_t)(PlayerCamera* camera, Actor* target);
 		SetCameraTarget_t SetCameraTarget = (SetCameraTarget_t)g_setCamTargetAddr;
-
 		SetCameraTarget(this, target);
 	}
+
 
 	void PlayerCamera::ForceFirstPerson()
 	{
 		typedef void(*ForceFirstPerson_t)(PlayerCamera * camera);
 		ForceFirstPerson_t ForceFirstPerson = (ForceFirstPerson_t)g_forceFirstPersonAddr;
-
 		ThirdPersonState* tps = GetThirdPersonCamera();
 		tps->savedZoom = tps->curPosY;
-
 		ForceFirstPerson(this);
 	}
+
 
 	void PlayerCamera::ForceThirdPerson()
 	{
 		ThirdPersonState * tps = GetThirdPersonCamera();
-
 		tps->basePosX = tps->fOverShoulderPosX;
 		tps->basePosY = tps->fOverShoulderCombatAddY;
 		tps->basePosZ = tps->fOverShoulderPosZ;
 		tps->dstPosY = tps->savedZoom;
-
 		SetCameraState(tps);
 	}
+
 
 	void PlayerCamera::UpdateThirdPersonMode(bool weaponDrawn)
 	{
 		typedef void(*UpdateThirdPersonMode_t)(PlayerCamera * camera, bool weaponDrawn);
 		UpdateThirdPersonMode_t UpdateThirdPersonMode = (UpdateThirdPersonMode_t)g_updateThirdPersonAddr;
-
 		UpdateThirdPersonMode(this, weaponDrawn);
 	}
+
 
 	bool PlayerCamera::GetDistanceWithTargetBone(Actor * target, NiPoint3 * dist)
 	{
 		NiPoint3 targetPos;
-
 		target->GetTargetNeckPosition(&targetPos);
-
 		dist->x = targetPos.x - cameraPos.x;
 		dist->y = targetPos.y - cameraPos.y;
 		dist->z = targetPos.z - cameraPos.z;
-
 		return true;
 	}
+
 
 	float PlayerCamera::GetDistanceWithTargetBone(Actor * target, bool firstPerson)
 	{
@@ -256,54 +257,47 @@ namespace Tralala
 		return sqrt(dx*dx + dy*dy + dz*dz);
 	}
 
-	bool PlayerCamera::GetPenetration(Actor * target, NiPoint3* sourcePos, float radiusToCheck, 
-		float offsetActorFromGround)
+
+	bool PlayerCamera::GetPenetration(Actor * target, NiPoint3* sourcePos, float radiusToCheck, float offsetActorFromGround)
 	{
 		typedef bool(*GetPenetration_t)(SimpleShapePhantom*, Actor *, NiPoint3*, float, float);
 		GetPenetration_t GetPenetration = (GetPenetration_t)g_getPenetrationAddr;
-
 		return GetPenetration(simpleShapePhantoms, target, sourcePos, radiusToCheck, offsetActorFromGround);
 	}
+
 
 	bool PlayerCamera::GetClosestPoint(void* bhkWorldM, NiPoint3* sourcePos, NiPoint3* resultPos,
 		Havok::hkpRootCdPoint* resultInfo, Actor** resultActor, float radiusToCheck)
 	{
-		typedef bool(*GetClosestPoint_t)(SimpleShapePhantom*, void*, NiPoint3*, 
-			NiPoint3*, Havok::hkpRootCdPoint*, Actor**, float);
+		typedef bool(*GetClosestPoint_t)(SimpleShapePhantom*, void*, NiPoint3*, NiPoint3*, Havok::hkpRootCdPoint*, Actor**, float);
 		GetClosestPoint_t GetClosestPoint = (GetClosestPoint_t)g_getClosestPointAddr;
-
-		return GetClosestPoint(simpleShapePhantoms, bhkWorldM, sourcePos, resultPos, 
-			resultInfo, resultActor, radiusToCheck);
+		return GetClosestPoint(simpleShapePhantoms, bhkWorldM, sourcePos, resultPos, resultInfo, resultActor, radiusToCheck);
 	}
+
 
 	bool PlayerCamera::ProcessCollision(NiPoint3* camPos, bool isFade)
 	{
 		typedef bool(*ProcessCollision_t)(PlayerCamera*, NiPoint3*, bool);
 		ProcessCollision_t ProcessCollision = (ProcessCollision_t)g_camProcessColAddr;
-
 		return ProcessCollision(this, camPos, isFade);
 	}
+
 
 	bool PlayerCamera::IsInCameraView(NiPoint3* pos, int mode)
 	{
 		NiCamera* niCamera = GetNiCamera();
-		if (!niCamera)
-			return false;
+		if (!niCamera) return false;
 	
 		// project a world space point to screen space
-		float w = pos->x * niCamera->m_aafWorldToCam[3][0] +
-			pos->y * niCamera->m_aafWorldToCam[3][1] + pos->z * niCamera->m_aafWorldToCam[3][2] +
-			niCamera->m_aafWorldToCam[3][3];
+		float w = pos->x * niCamera->m_aafWorldToCam[3][0] + pos->y * niCamera->m_aafWorldToCam[3][1] + pos->z * niCamera->m_aafWorldToCam[3][2] + niCamera->m_aafWorldToCam[3][3];
 
 		// Check to see if we're on the appropriate side of the camera.
 		if (w > 1e-5f)
 		{
 			float invW = 1.0f / w;
 
-			float screenX = pos->x * niCamera->m_aafWorldToCam[0][0] + pos->y * niCamera->m_aafWorldToCam[0][1] +
-				pos->z * niCamera->m_aafWorldToCam[0][2] + niCamera->m_aafWorldToCam[0][3];
-			float screenY = pos->x * niCamera->m_aafWorldToCam[1][0] + pos->y * niCamera->m_aafWorldToCam[1][1] +
-				pos->z * niCamera->m_aafWorldToCam[1][2] + niCamera->m_aafWorldToCam[1][3];
+			float screenX = pos->x * niCamera->m_aafWorldToCam[0][0] + pos->y * niCamera->m_aafWorldToCam[0][1] + pos->z * niCamera->m_aafWorldToCam[0][2] + niCamera->m_aafWorldToCam[0][3];
+			float screenY = pos->x * niCamera->m_aafWorldToCam[1][0] + pos->y * niCamera->m_aafWorldToCam[1][1] + pos->z * niCamera->m_aafWorldToCam[1][2] + niCamera->m_aafWorldToCam[1][3];
 
 			screenX *= invW;
 			screenY *= invW;
@@ -317,39 +311,35 @@ namespace Tralala
 			// If on screen return true. Otherwise, we fall through to false.
 			switch (mode)
 			{
-			case kRotate_Fast:
-			{
-				if (screenX >= 0.3125f && screenX <= 0.6875f &&
-					screenY >= 0.28125f && screenY <= 0.71785f)
+				case kRotate_Fast:
 				{
-					return true;
+					if (screenX >= 0.3125f && screenX <= 0.6875f && screenY >= 0.28125f && screenY <= 0.71785f)
+					{
+						return true;
+					}
+					break;
 				}
-				break;
-			}
-			case kRotate_Slow:
-			{
-				if (screenX >= 0.375f && screenX <= 0.625f &&
-					screenY >= 0.34375f && screenY <= 0.65625f)
+				case kRotate_Slow:
 				{
-					return true;
+					if (screenX >= 0.375f && screenX <= 0.625f && screenY >= 0.34375f && screenY <= 0.65625f)
+					{
+						return true;
+					}
+					break;
 				}
-				break;
-			}
-			case KRotate_Stop:
-			{
-				if (screenX >= 0.4375f && screenX <= 0.5625f &&
-					screenY >= 0.40625f && screenY <= 0.59375f)
+				case KRotate_Stop:
 				{
-					return true;
+					if (screenX >= 0.4375f && screenX <= 0.5625f && screenY >= 0.40625f && screenY <= 0.59375f)
+					{
+						return true;
+					}
+					break;
 				}
-				break;
-			}
-			default:
-				return false;
+				default:
+					return false;
 			}
 		}
 
 		return false;
-		
 	}
 }

--- a/Controls.cpp
+++ b/Controls.cpp
@@ -1,10 +1,12 @@
 #include "Controls.h"
 #include "PatternScanner.h"
 
+
 namespace Tralala
 {
 	uintptr_t g_playerControlsAddr = 0;
 	uintptr_t g_menuControlsAddr = 0;
+
 
 	void ControlsGetAddresses()
 	{
@@ -15,10 +17,12 @@ namespace Tralala
 		g_menuControlsAddr = (uintptr_t)scan_memory_data(menupattern, 0x27, false, 0x3, 0x7);
 	}
 
+
 	MenuControls * MenuControls::GetSingleton()
 	{
 		return *(MenuControls**)g_menuControlsAddr;
 	}
+
 
 	PlayerControls* PlayerControls::GetSingleton()
 	{

--- a/Graphics.cpp
+++ b/Graphics.cpp
@@ -8,11 +8,13 @@
 
 #pragma comment(lib, "d3dcompiler.lib")
 
+
 uintptr_t g_unkStructAddr = 0;
 uintptr_t g_presentAddr = 0;
 uintptr_t g_swapChainAddr = 0;
 uintptr_t g_menuRenderAddr = 0;
 uintptr_t g_cleanAddr = 0;
+
 
 namespace Tralala
 {
@@ -29,6 +31,7 @@ namespace Tralala
 	ID3D10Blob* pBlob = nullptr;
 
 	D3D11_VIEWPORT pViewports[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE]{ 0 };
+
 
 	struct ConstantBuffer
 	{
@@ -81,6 +84,7 @@ namespace Tralala
 		_MESSAGE("Done.");
 	}
 
+
 	static HRESULT GetDeviceAndCtxFromSwapchain(IDXGISwapChain* pSwapChain, ID3D11Device** ppDevice, ID3D11DeviceContext** ppContext)
 	{
 		HRESULT ret = pSwapChain->GetDevice(__uuidof(ID3D11Device), (PVOID*)ppDevice);
@@ -92,6 +96,7 @@ namespace Tralala
 
 		return ret;
 	}
+
 
 	static bool CompileShader(const char* szShader, const char* szEntrypoint, const char* szTarget, ID3D10Blob** pBlob)
 	{
@@ -111,6 +116,7 @@ namespace Tralala
 		}
 		return true;
 	}
+
 
 #if 1
 	static void DrawLetterBox(ID3D11DeviceContext* context, UINT numVertices, float dstPosY)
@@ -155,7 +161,8 @@ namespace Tralala
 		static float speed = 0.005f;
 #endif
 
-		if (!g_bInitialised) {
+		if (!g_bInitialised)
+		{
 			if (FAILED(GetDeviceAndCtxFromSwapchain(pSwapChain, &pDevice, &pContext)))
 			{
 				CleanupD3D11();
@@ -344,11 +351,13 @@ namespace Tralala
 #endif
 }
 
+
 #include "skse64_common/Utilities.h"
 #include "skse64_common/Relocation.h"
 #include "skse64_common/BranchTrampoline.h"
 #include "skse64_common/SafeWrite.h"
 #include "xbyak/xbyak.h"
+
 
 namespace Graphics
 {
@@ -370,10 +379,12 @@ namespace Graphics
 #endif
 	}
 
+
 	bool InstallHook()
 	{
 		{
-			struct InstallHookPresent_Code : Xbyak::CodeGenerator {
+			struct InstallHookPresent_Code : Xbyak::CodeGenerator
+			{
 				InstallHookPresent_Code(void* buf, uintptr_t funcAddr) : Xbyak::CodeGenerator(4096, buf)
 				{
 					Xbyak::Label retnLabel;
@@ -414,7 +425,8 @@ namespace Graphics
 		}
 
 		{
-			struct InstallHookDtor_Code : Xbyak::CodeGenerator {
+			struct InstallHookDtor_Code : Xbyak::CodeGenerator
+			{
 				InstallHookDtor_Code(void* buf, uintptr_t funcAddr) : Xbyak::CodeGenerator(4096, buf)
 				{
 					Xbyak::Label retnLabel;
@@ -457,4 +469,3 @@ namespace Graphics
 		return true;
 	}
 }
-

--- a/Havok.cpp
+++ b/Havok.cpp
@@ -6,6 +6,7 @@ namespace Havok
 {
 	uintptr_t g_getNiObjectAddr = 0;
 
+
 	void GetAddresses()
 	{
 		const std::array<BYTE, 6> pattern = { 0x8B, 0x79, 0x2C, 0x83, 0xE7, 0x7F };

--- a/Menus.cpp
+++ b/Menus.cpp
@@ -5,6 +5,7 @@
 #include "Settings.h"
 #include "PatternScanner.h"
 
+
 uintptr_t g_hudMenuNextFrameAddr = 0;
 uintptr_t g_barterMenuDtorAddr = 0;
 uintptr_t g_trainingMenuCtorAddr = 0;
@@ -12,9 +13,11 @@ uintptr_t g_trainingMenuDtorAddr = 0;
 uintptr_t g_dialMenuVtblAddr = 0;
 uintptr_t g_dialNextFrameAddr = 0;
 
+
 namespace Tralala
 {
 	bool g_isTrainingMenu = false;
+
 
 	void HUDMenuNextFrame_Hook(HUDMenu* hudMenu)
 	{
@@ -71,21 +74,25 @@ namespace Tralala
 		}
 	}
 
+
 	void BarterMenuDtor_Hook()
 	{
 		UInt32 invalidHandle = InvalidRefHandle();
 		*(UInt32*)g_barterHandle = invalidHandle;
 	}
 
+
 	void TrainingMenuCtor_Hook()
 	{
 		g_isTrainingMenu = true;
 	}
 
+
 	void TrainingMenuDtor_Hook()
 	{
 		g_isTrainingMenu = false;
 	}
+
 
 	void DialMenuNextFrame_Hook(IMenu* menu, float unk1, UInt32 unk2)
 	{
@@ -164,11 +171,13 @@ namespace Tralala
 	}
 }
 
+
 #include "skse64_common/Utilities.h"
 #include "skse64_common/Relocation.h"
 #include "skse64_common/BranchTrampoline.h"
 #include "skse64_common/SafeWrite.h"
 #include "xbyak/xbyak.h"
+
 
 namespace Menus
 {
@@ -192,10 +201,12 @@ namespace Menus
 		g_dialNextFrameAddr = (uintptr_t)((void**)g_dialMenuVtblAddr)[5];
 	}
 
+
 	bool InstallHook()
 	{
 		{
-			struct InstallHookHUDNextFrameCode : Xbyak::CodeGenerator {
+			struct InstallHookHUDNextFrameCode : Xbyak::CodeGenerator
+			{
 				InstallHookHUDNextFrameCode(void* buf, uintptr_t funcAddr) : Xbyak::CodeGenerator(4096, buf)
 				{
 					Xbyak::Label retnLabel;
@@ -240,7 +251,8 @@ namespace Menus
 		}
 
 		{
-			struct InstallHookBarterDtorCode : Xbyak::CodeGenerator {
+			struct InstallHookBarterDtorCode : Xbyak::CodeGenerator
+			{
 				InstallHookBarterDtorCode(void* buf, uintptr_t funcAddr) : Xbyak::CodeGenerator(4096, buf)
 				{
 					Xbyak::Label retnLabel;
@@ -282,7 +294,8 @@ namespace Menus
 		}
 
 		{
-			struct InstallHookTrainCtorCode : Xbyak::CodeGenerator {
+			struct InstallHookTrainCtorCode : Xbyak::CodeGenerator
+			{
 				InstallHookTrainCtorCode(void* buf, uintptr_t funcAddr) : Xbyak::CodeGenerator(4096, buf)
 				{
 					Xbyak::Label retnLabel;
@@ -319,13 +332,13 @@ namespace Menus
 			InstallHookTrainCtorCode code(codeBuf, GetFnAddr(Tralala::TrainingMenuCtor_Hook));
 			g_localTrampoline.EndAlloc(code.getCurr());
 
-
 			if (!g_branchTrampoline.Write5Branch(g_trainingMenuCtorAddr, uintptr_t(code.getCode())))
 				return false;
 		}
 
 		{
-			struct InstallHookTrainDtorCode : Xbyak::CodeGenerator {
+			struct InstallHookTrainDtorCode : Xbyak::CodeGenerator
+			{
 				InstallHookTrainDtorCode(void* buf, uintptr_t funcAddr) : Xbyak::CodeGenerator(4096, buf)
 				{
 					Xbyak::Label retnLabel;

--- a/Menus.cpp
+++ b/Menus.cpp
@@ -18,7 +18,8 @@ namespace Tralala
 
 	void HUDMenuNextFrame_Hook(HUDMenu* hudMenu)
 	{
-		if (!Settings::bLetterBox)
+		/* Ignore the whole shebang if feature isn't enabled in settings! */
+		if (!Settings::bEnableHUDMessagePositioning || !Settings::bLetterBox)
 			return;
 
 		GFxValue messagesBlock;

--- a/ObjectRef.cpp
+++ b/ObjectRef.cpp
@@ -1,6 +1,7 @@
 #include "ObjectRef.h"
 #include "skse64/NiNodes.h"
 
+
 namespace Tralala
 {
 	uintptr_t g_playerCharacterAddr = 0;
@@ -22,6 +23,7 @@ namespace Tralala
 	uintptr_t g_getbhkWorldMAddr = 0;
 	uintptr_t g_unk_0x5ECF90Addr = 0;
 	uintptr_t g_isInAirAddr = 0;
+
 
 	void ObjectRefGetAddresses()
 	{
@@ -82,69 +84,70 @@ namespace Tralala
 		g_isInAirAddr = (uintptr_t)scan_memory_data(airpattern, 0x9B, false, 0x1, 0x5);
 	}
 
+
 	void ActorProcessManager::SetTargetLocation(TESObjectREFR* source, NiPoint3* location)
 	{
 		typedef void(*SetTargetLocation_t)(ActorProcessManager*, TESObjectREFR*, NiPoint3*);
 		SetTargetLocation_t SetTargetLocation = (SetTargetLocation_t)g_setTargetLocAddr;
-
 		SetTargetLocation(this, source, location);
 	}
+
 
 	void ActorProcessManager::SetDialogueHeadTrackingTarget(TESObjectREFR* target)
 	{
 		typedef void(*SetDialogueHTTarget_t)(ActorProcessManager*, TESObjectREFR*);
 		SetDialogueHTTarget_t SetTarget = (SetDialogueHTTarget_t)g_setDialogueAddr;
-
 		SetTarget(this, target);
 	}
+
 
 	void ActorProcessManager::ClearHeadTracking()
 	{
 		typedef void(*ClearHeadTracking_t)(ActorProcessManager*);
 		ClearHeadTracking_t ClearHeadTracking = (ClearHeadTracking_t)g_clearHeadTrackAddr;
-
 		ClearHeadTracking(this);
 	}
+
 
 	UInt32* ActorProcessManager::GetFurnitureHandle(UInt32* handle)
 	{
 		typedef UInt32* (*GetFurnitureHandle_t)(ActorProcessManager*, UInt32*);
 		GetFurnitureHandle_t GetFurnitureHandle = (GetFurnitureHandle_t)g_getFurnHandleAddr;
-
 		return GetFurnitureHandle(this, handle);
 	}
+
 
 	bool IAnimationGraphManagerHolder::SetAnimationVariableBool(const BSFixedString& variableName, bool value)
 	{
 		typedef bool(*SetAnimVarBool_t)(IAnimationGraphManagerHolder*, const BSFixedString&, bool);
 		SetAnimVarBool_t SetAnimVarBool = (SetAnimVarBool_t)g_setAnimBoolAddr;
-
 		return SetAnimVarBool(this, variableName, value);
 	}
+
 
 	UInt32 InvalidRefHandle()
 	{
 		return *(UInt32*)g_invalidRefHandleAddr;
 	}
 
+
 	bool LookupRefByHandle(UInt32& refHandle, NiPointer<TESObjectREFR>& refrOut)
 	{
 		typedef bool(*LookupREFRByHandle_t)(UInt32 &, NiPointer<TESObjectREFR> &);
 		LookupREFRByHandle_t LookupREFRByHandle = (LookupREFRByHandle_t)g_lookupAddr;
-
 		return LookupREFRByHandle(refHandle, refrOut);
 	}
+
 
 	float TESObjectREFR::GetDistance(TESObjectREFR * target)
 	{
 		float x, y, z;
-
 		x = pos.x - target->pos.x;
 		y = pos.y - target->pos.y;
 		z = pos.z - target->pos.z;
-
 		return sqrt(x*x + y*y + z*z);
 	}
+
 
 	float TESObjectREFR::GetTargetHeight()
 	{
@@ -152,20 +155,20 @@ namespace Tralala
 		return GetBoundRightBackTop(&p1)->z - GetBoundLeftFrontBottom(&p2)->z;
 	}
 
+
 	float TESObjectREFR::GetTargetWidth()
 	{	
 		NiPoint3 p1, p2;
 		return GetBoundRightBackTop(&p1)->x - GetBoundLeftFrontBottom(&p2)->x;
 	}
 
+
 	void* TESObjectREFR::GetbhkWorldM()
 	{
-		if (!parentCell)
-			return nullptr;
+		if (!parentCell) return nullptr;
 
 		typedef void* (*GetbhkWorldM_t)(TESObjectCELL*);
 		GetbhkWorldM_t GetbhkWorldM = (GetbhkWorldM_t)g_getbhkWorldMAddr;
-
 		return GetbhkWorldM(parentCell);
 	}
 
@@ -174,118 +177,111 @@ namespace Tralala
 		handleRefObject.IncRef();
 	}
 
+
 	void TESObjectREFR::DecRef()
 	{
 		handleRefObject.DecRef();
 	}
 
+
 	bool Actor::IsOnMount()
 	{
 		typedef bool(*IsOnMount_t)(Actor*);
 		IsOnMount_t IsOnMount = (IsOnMount_t)g_isonmountAddr;
-
 		return IsOnMount(this);
 	}
+
 
 	bool Actor::IsOnCarriage()
 	{
 		UInt32 handle = 0;
 		processManager->GetFurnitureHandle(&handle);
-
 		UInt32 sitState = actorState.GetSitState();
-		if ((sitState == ActorState::kSitState_Sitting) && (handle == InvalidRefHandle()))
-			return true;
-
+		if ((sitState == ActorState::kSitState_Sitting) && (handle == InvalidRefHandle())) return true;
 		return false;
 	}
+
 
 	bool Actor::IsTalking()
 	{
-		if ((flags1 & 0x180) != 0x180)
-			return true;
-
-		if (unk108 > 0)
-			return true;
-
+		if ((flags1 & 0x180) != 0x180) return true;
+		if (unk108 > 0) return true;
 		return false;
 	}
+
 
 	bool Actor::IsInAir()
 	{
 		typedef bool(*IsInAir_t)(Actor*);
 		IsInAir_t IsInAir = (IsInAir_t)g_isInAirAddr;
-
 		return IsInAir(this);
 	}
+
 
 	void Actor::SetAngleX(float angle)
 	{
 		typedef void(*SetAngleX_t)(Actor * actor, float angle);
 		SetAngleX_t SetAngleX = (SetAngleX_t)g_setAngleXAddr;
-
 		SetAngleX(this, angle);
 	}
 	
+
 	void Actor::SetAngleZ(float angle)
 	{
 		typedef void(*SetAngleZ_t)(Actor * actor, float angle);
 		SetAngleZ_t SetAngleZ = (SetAngleZ_t)g_setAngleZAddr;
-
 		SetAngleZ(this, angle);
 	}
+
 
 	void Actor::GetTargetNeckPosition(NiPoint3 * pos)
 	{
 		NiAVObject* node = this->GetNiNode();
-		if (!node)
-			return GetMarkerPosition(pos);
+		if (!node) return GetMarkerPosition(pos);
 		
 		BSFixedString neckName("NPC Neck [Neck]");
 		node = node->GetObjectByName(&neckName.data);
-		if (!node)
-			return GetMarkerPosition(pos);
+		if (!node) return GetMarkerPosition(pos);
 
 		pos->x = node->m_worldTransform.pos.x;
 		pos->y = node->m_worldTransform.pos.y;
 		pos->z = node->m_worldTransform.pos.z;
 	}
 
+
 	TESObjectWEAP* Actor::GetEquippedWeapon(bool isLeftHand)
 	{
 		typedef TESObjectWEAP * (*GetEquippedWeapon_t)(Actor * actor, bool isLeftHand);
 		GetEquippedWeapon_t GetEquippedWeapon = (GetEquippedWeapon_t)g_equipWeaponAddr;
-
 		return GetEquippedWeapon(this, isLeftHand);
 	}
+
 
 	bool Actor::IsFlyingActor()
 	{
 		return ((race->data.raceFlags & TESRace::kRace_Flies) == TESRace::kRace_Flies);
 	}
 
+
 	bool Actor::IsNotInFurniture()
 	{
 		return ((actorState.flags08 & 0x0003C000) == 0);
 	}
 
+
 	bool Actor::IsCasting(MagicItem* spell)
 	{
 		typedef bool(*IsCasting_t)(Actor*, MagicItem*);
 		IsCasting_t IsCasting = (IsCasting_t)g_isCastingAddr;
-
 		return IsCasting(this, spell);
 	}
 
+
 	bool Actor::GetTargetHeadNodePosition(NiPoint3 * pos, bool * compare)
 	{
-		if (!processManager)
-			return false;
-
-		if (!processManager->middleProcess)
-			return false;
-
-		if (!processManager->middleProcess->unk158)
-			return false;
+		if (!processManager) return false;
+		if (!processManager->middleProcess) return false;
+		if (!processManager->middleProcess->unk158) return false;
 
 		NiNode* headNode = (NiNode*)processManager->middleProcess->unk158;
 
@@ -293,77 +289,72 @@ namespace Tralala
 		{
 			BSFixedString headName("NPC Head [Head]");
 			BSFixedString name(headNode->m_name);
-			if (name == headName)
-				*compare = true;
-			else
-				*compare = false;
+			if (name == headName) *compare = true;
+			else *compare = false;
 		}
 
 		pos->x = headNode->m_worldTransform.pos.x;
 		pos->y = headNode->m_worldTransform.pos.y;
 		pos->z = headNode->m_worldTransform.pos.z;
 
-		
-
 		return true;
 	}
-	
+
+
 	bool Actor::IsSneaking()
 	{
 		typedef bool(*IsSneaking_t)(Actor*);
 		IsSneaking_t IsSneaking = (IsSneaking_t)g_isSneakingAddr;
-
 		return IsSneaking(this);
 	}
+
 
 	float Actor::GetSneakingHeight(bool isCamera)
 	{
 		typedef float(*GetSneakingHeight_t)(Actor*, bool);
 		GetSneakingHeight_t GetSneakingHeight = (GetSneakingHeight_t)g_sneakingHeightAddr;
-
 		return GetSneakingHeight(this, isCamera);
 	}
+
 
 	float Actor::GetCameraHeight()
 	{
 		typedef float(*GetCameraHeight_t)(Actor*);
 		GetCameraHeight_t GetCameraHeight = (GetCameraHeight_t)g_cameraHeightAddr;
-
 		return GetCameraHeight(this);
 	}
+
 
 	void Actor::Unk_0x5ECF90()
 	{
 		typedef void(*Unk_0x5ECF90_t)(Actor*);
 		Unk_0x5ECF90_t Unk_0x5ECF90 = (Unk_0x5ECF90_t)g_unk_0x5ECF90Addr;
-
 		return Unk_0x5ECF90(this);
 	}
+
 
 	PlayerCharacter * PlayerCharacter::GetSingleton()
 	{
 		return *(PlayerCharacter**)g_playerCharacterAddr;
 	}
 
+
 	bool PlayerCharacter::SetIsNPCAnimVar(bool var)
 	{
 		BSFixedString isNPCVar("IsNPC");
 		bool ret = false;
 
-		if (this)
-			ret = this->animGraphHolder.SetAnimationVariableBool(isNPCVar, var);
-		
+		if (this) ret = this->animGraphHolder.SetAnimationVariableBool(isNPCVar, var);
 		return ret;
 	}
+
 
 	bool PlayerCharacter::GetIsNPCAnimVar()
 	{
 		BSFixedString isNPCVar("IsNPC");
 		bool ret = false;
 
-		if (this)
-			this->animGraphHolder.GetAnimationVariableBool(isNPCVar, ret);
-
+		if (this) this->animGraphHolder.GetAnimationVariableBool(isNPCVar, ret);
 		return ret;
 	}
 }

--- a/ObjectRef.h
+++ b/ObjectRef.h
@@ -147,7 +147,7 @@ namespace Tralala
 		virtual void		Unk_7B(void);
 		virtual void		Unk_7C(void);
 		virtual void		Unk_7D(void);
-		//virtual ActorWeightModel	* GetWeightModel(UInt32 weightModel); // 0 Small 1 Large
+		virtual class ActorWeightModel	* GetWeightModel(UInt32 weightModel); // 0 Small 1 Large
 		virtual void		Unk_7F(void);
 		virtual void		Unk_80(void);
 		virtual void		Unk_81(void);

--- a/ObjectRef.h
+++ b/ObjectRef.h
@@ -147,7 +147,7 @@ namespace Tralala
 		virtual void		Unk_7B(void);
 		virtual void		Unk_7C(void);
 		virtual void		Unk_7D(void);
-		virtual ActorWeightModel	* GetWeightModel(UInt32 weightModel); // 0 Small 1 Large
+		//virtual ActorWeightModel	* GetWeightModel(UInt32 weightModel); // 0 Small 1 Large
 		virtual void		Unk_7F(void);
 		virtual void		Unk_80(void);
 		virtual void		Unk_81(void);

--- a/ScaleformUtils.cpp
+++ b/ScaleformUtils.cpp
@@ -1,6 +1,7 @@
 #include "ScaleformUtils.h"
 #include "PatternScanner.h"
 
+
 namespace Tralala
 {
 	uintptr_t g_scaleFormHeapAddr = 0;
@@ -11,6 +12,7 @@ namespace Tralala
 	uintptr_t g_getMemberAddr = 0;
 	uintptr_t g_setMemberAddr = 0;
 	uintptr_t g_setTextAddr = 0;
+
 
 	void ScaleformUtilGetAddresses()
 	{
@@ -45,29 +47,33 @@ namespace Tralala
 		return *(ScaleformHeap * *)g_scaleFormHeapAddr;
 	}
 
+
 	void* ScaleformHeap_Allocate(UInt32 size)
 	{
 		return ScaleformHeap::GetSingleton()->Allocate(size);
 	}
+
 
 	void ScaleformHeap_Free(void* ptr)
 	{
 		return ScaleformHeap::GetSingleton()->Free(ptr);
 	}
 
+
 	GFxValue::~GFxValue()
 	{
 		CleanManaged();
 	}
+
 
 	void GFxValue::AddManaged()
 	{
 		typedef void(*AddManaged_Internal_t)(ObjectInterface*, GFxValue*, void*);
 		AddManaged_Internal_t AddManaged_Internal = (AddManaged_Internal_t)g_addManagedAddr;
 
-		if (IsManaged())
-			AddManaged_Internal(objectInterface, this, data.obj);
+		if (IsManaged()) AddManaged_Internal(objectInterface, this, data.obj);
 	}
+
 
 	void GFxValue::AddManaged(const GFxValue& src)
 	{
@@ -80,6 +86,7 @@ namespace Tralala
 			AddManaged_Internal(objectInterface, this, data.obj);
 		}
 	}
+
 
 	void GFxValue::CleanManaged()
 	{
@@ -95,45 +102,46 @@ namespace Tralala
 		}
 	}
 
+
 	bool GFxValue::GetDisplayInfo(DisplayInfo* displayInfo)
 	{
 		typedef bool(*GetDisplayInfo_t)(ObjectInterface*, void*, DisplayInfo*);
 		GetDisplayInfo_t GetDisplayInfo = (GetDisplayInfo_t)g_getDispInfoAddr;
-
 		return GetDisplayInfo(objectInterface, data.obj, displayInfo);
 	}
+
 
 	bool GFxValue::SetDisplayInfo(DisplayInfo* displayInfo)
 	{
 		typedef bool(*SetDisplayInfo_t)(ObjectInterface*, void*, DisplayInfo*);
 		SetDisplayInfo_t SetDisplayInfo = (SetDisplayInfo_t)g_setDispInfoAddr;
-
 		return SetDisplayInfo(objectInterface, data.obj, displayInfo);
 	}
+
 
 	bool GFxValue::GetMember(const char* name, GFxValue* value)
 	{
 		typedef bool(*GetMember_t)(ObjectInterface*, void*, const char*, GFxValue*, bool);
 		GetMember_t GetMember = (GetMember_t)g_getMemberAddr;
-
 		return GetMember(objectInterface, data.obj, name, value, IsDisplayObject());
 	}
+
 
 	bool GFxValue::SetMember(const char* name, GFxValue* value)
 	{
 		typedef bool(*SetMember_t)(ObjectInterface*, void*, const char*, GFxValue*, bool);
 		SetMember_t SetMember = (SetMember_t)g_setMemberAddr;
-
 		return SetMember(objectInterface, data.obj, name, value, IsDisplayObject());
 	}
+
 
 	bool GFxValue::SetText(const char* text, bool html)
 	{
 		typedef bool(*SetText_t)(ObjectInterface*, void*, const char*, bool);
 		SetText_t SetText = (SetText_t)g_setTextAddr;
-
 		return SetText(objectInterface, data.obj, text, html);
 	}
+
 
 	void GFxValue::SetString(const char* value)
 	{
@@ -143,6 +151,7 @@ namespace Tralala
 		data.string = value;
 	}
 
+
 	void GFxValue::SetNumber(double value)
 	{
 		CleanManaged();
@@ -151,14 +160,11 @@ namespace Tralala
 		data.number = value;
 	}
 
+
 	const char* GFxValue::GetString(void) const
 	{
-		if (GetType() != kType_String)
-			return NULL;
-
-		if (IsManaged())
-			return *data.managedString;
-		else
-			return data.string;
+		if (GetType() != kType_String) return NULL;
+		if (IsManaged()) return *data.managedString;
+		else return data.string;
 	}
 }

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -13,6 +13,7 @@ bool	Settings::bHeadTracking = true;
 bool	Settings::bConversationHT = true;
 bool	Settings::bLetterBox = true;
 bool	Settings::bHideDialogueMenu = true;
+bool	Settings::bEnableHUDMessagePositioning = true;
 int		Settings::uLetterBoxThickness = 175;
 int		Settings::uLetterBoxSpeed = 5;
 float	Settings::fCameraSpeed = 500.0f;
@@ -69,6 +70,7 @@ void Settings::Load()
 	Settings::bHeadTracking = GetPrivateProfileInt(L"Settings", L"bHeadTracking", 1, thisPath.c_str());
 	Settings::bConversationHT = GetPrivateProfileInt(L"Settings", L"bConversationHT", 1, thisPath.c_str());
 	Settings::bLetterBox = GetPrivateProfileInt(L"Settings", L"bLetterBox", 1, thisPath.c_str());
+	Settings::bEnableHUDMessagePositioning = GetPrivateProfileInt(L"Settings", L"bEnableHUDMessagePositioning", 1, thisPath.c_str());
 	Settings::uLetterBoxThickness = GetPrivateProfileInt(L"Settings", L"uLetterBoxThickness", 175, thisPath.c_str());
 	Settings::uLetterBoxSpeed = GetPrivateProfileInt(L"Settings", L"uLetterBoxSpeed", 5, thisPath.c_str());
 	Settings::fCameraSpeed = GetPrivateProfileInt(L"Settings", L"fCameraSpeed", 500, thisPath.c_str());

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -4,6 +4,7 @@
 
 #pragma comment(lib, "shlwapi.lib")
 
+
 bool	Settings::bLockOn = true;
 bool	Settings::bForceFirstPerson = true;
 bool	Settings::bSmoothTransition = true;
@@ -34,18 +35,19 @@ float	Settings::fCreatureCamOffsetZ = 15.0f;
 
 std::wstring thisPath = L"";
 
+
 void Settings::Load()
 {
 	TCHAR path[MAX_PATH];
 	HMODULE hm;
-	if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-		GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-		L"AlternateConversationCamera.dll", &hm))
+	if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, L"AlternateConversationCamera.dll", &hm))
 	{
 		GetModuleFileName(hm, path, MAX_PATH);
 		PathRemoveFileSpec(path);
 		thisPath = std::wstring(path);
-		if (!thisPath.empty() && thisPath.at(thisPath.length() - 1) != '\\'){
+
+		if (!thisPath.empty() && thisPath.at(thisPath.length() - 1) != '\\')
+		{
 			thisPath += L"\\AlternateConversationCamera.ini";
 		}
 	}
@@ -78,13 +80,12 @@ void Settings::Load()
 	Settings::f3rdZoom = GetPrivateProfileInt(L"Settings", L"u3rdZoom", 75, thisPath.c_str());
 	Settings::fDragonZoom = GetPrivateProfileInt(L"Settings", L"uDragonZoom", 125, thisPath.c_str());
 	Settings::bHideDialogueMenu = GetPrivateProfileInt(L"Settings", L"bHideDialogueMenu", 1, thisPath.c_str());
+
 	GetPrivateProfileString(L"Settings", L"iAddOverShoulderPosX", L"50", posX, 8, thisPath.c_str());
 	GetPrivateProfileString(L"Settings", L"iAddOverShoulderPosZ", L"-5", posZ, 8, thisPath.c_str());
 	GetPrivateProfileString(L"Settings", L"iAddOverShoulderPosY", L"0", posY, 8, thisPath.c_str());
-
 	GetPrivateProfileString(L"Settings", L"iMessagePosX", L"-601", mesPosX, 8, thisPath.c_str());
 	GetPrivateProfileString(L"Settings", L"iMessagePosY", L"-400", mesPosY, 8, thisPath.c_str());
-
 	GetPrivateProfileString(L"Settings", L"iHumanCamOffsetX", L"0", humanCamX, 8, thisPath.c_str());
 	GetPrivateProfileString(L"Settings", L"iHumanCamOffsetY", L"0", humanCamY, 8, thisPath.c_str());
 	GetPrivateProfileString(L"Settings", L"iHumanCamOffsetZ", L"5", humanCamZ, 8, thisPath.c_str());

--- a/Settings.h
+++ b/Settings.h
@@ -28,6 +28,6 @@ struct Settings
 	static bool		bConversationHT;
 	static bool		bLetterBox;
 	static bool		bHideDialogueMenu;
-
+	static bool		bEnableHUDMessagePositioning;
 	static void Load();
 };

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -2,6 +2,7 @@
 #include "Utils.h"
 #include "PatternScanner.h"
 
+
 namespace Tralala
 {
 	uintptr_t g_MenuTopicManagerAddr = 0;
@@ -15,6 +16,7 @@ namespace Tralala
 	uintptr_t g_isDialogueMenuCloseAddr = 0;
 	uintptr_t g_containerHandle = 0;
 	uintptr_t g_barterHandle = 0;
+
 
 	void UtilsGetAddresses()
 	{
@@ -50,61 +52,59 @@ namespace Tralala
 
 		const std::array<BYTE, 7> bartpattern = { 0x4C, 0x8B, 0xEF, 0x48, 0x8B, 0x43, 0x28 };
 		g_barterHandle = (uintptr_t)scan_memory_data(bartpattern, 0x33, false, 0x3, 0x7);
-
 	}
+
 
 	TESCameraController* TESCameraController::GetSingleton()
 	{
 		return (TESCameraController*)g_TESCameraControllerAddr;
 	}
 
+
 	MenuTopicManager * MenuTopicManager::GetSingleton()
 	{
 		return *(MenuTopicManager**)g_MenuTopicManagerAddr;
 	}
 
+
 	NiPointer<TESObjectREFR> MenuTopicManager::GetDialogueTarget()
 	{
 		NiPointer<TESObjectREFR> refr;
-		if (talkingHandle != Tralala::InvalidRefHandle())
-			LookupRefByHandle(talkingHandle, refr);
-
+		if (talkingHandle != Tralala::InvalidRefHandle()) LookupRefByHandle(talkingHandle, refr);
 		if (!refr)
 		{
-			if (handle2 != Tralala::InvalidRefHandle())
-				LookupRefByHandle(handle2, refr);
+			if (handle2 != Tralala::InvalidRefHandle()) LookupRefByHandle(handle2, refr);
 		}
-
 		return refr;
 	}
+
 
 	StringCache::Ref::Ref()
 	{
 		typedef StringCache::Ref*(*ctor_t)(StringCache::Ref *, const char *);
 		ctor_t ctor = (ctor_t)g_bsfixedstringCtorAddr;
-
 		ctor(this, "");
 	}
+
 
 	StringCache::Ref::Ref(const char * buf)
 	{
 		typedef StringCache::Ref*(*ctor_t)(StringCache::Ref *, const char *);
 		ctor_t ctor = (ctor_t)g_bsfixedstringCtorAddr;
-
 		ctor(this, buf);
 	}
+
 
 	StringCache::Ref::~Ref()
 	{
 		Release();
 	}
 
+
 	void StringCache::Ref::Release()
 	{
 		typedef void(*dtor_t)(StringCache::Ref*);
 		dtor_t dtor = (dtor_t)g_bsfixedstringDtorAddr;
-
 		dtor(this);
 	}
-
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1165,7 +1165,10 @@ namespace Tralala
 				Havok::hkpRootCdPoint resultInfo;
 				Actor* resultActor = nullptr;
 
-				if (camera->GetClosestPoint(g_refTarget->GetbhkWorldM(), &targetHeadPos, &resultPos, &resultInfo,
+				// Make sure the world is valid before testing - If an actor is deleted during a converstaion, the world
+				// can become null, causing a crash.
+				auto world = g_refTarget->GetbhkWorldM();
+				if (world && camera->GetClosestPoint(world, &targetHeadPos, &resultPos, &resultInfo,
 					&resultActor, 1.0f))
 				{
 	#if 0

--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,7 @@
 
 #include <shlobj.h>
 
+
 IDebugLog				gLog;
 PluginHandle			g_pluginHandle = kPluginHandle_Invalid;
 
@@ -43,6 +44,7 @@ uintptr_t g_thirdCamHeightAddr = 0;
 uintptr_t g_thirdCamColAddr = 0;
 uintptr_t g_thirdCamUpdateAddr = 0;
 uintptr_t g_camCollisionAddr = 0;
+
 
 void MainGetAddresses()
 {
@@ -124,6 +126,7 @@ namespace Tralala
 
 	Actor* g_refTarget = nullptr;
 
+
 	static void SetZoom(float targetFOV)
 	{
 		float mult = roundf(1.0f / *(float*)g_deltaTimeAddr) / 60.0f;
@@ -135,6 +138,7 @@ namespace Tralala
 		g_fovStep = step;
 	}
 
+
 	static void ResetZoom()
 	{
 		float mult = roundf(1.0f / *(float*)g_deltaTimeAddr) / 60.0f;
@@ -145,6 +149,7 @@ namespace Tralala
 		g_firstfovTo = *(float*)g_defaultFirstFOVAddr;
 		g_fovStep = step;
 	}
+
 
 	static bool IsValidFaceToFace(PlayerCamera * camera, Actor** ret)
 	{
@@ -932,8 +937,7 @@ namespace Tralala
 	// TO DO - FIX THE FECKIN' CAMERA COLLISION
 	void TPCamProcessCollision_Hook(ThirdPersonState* tps)
 	{
-		if (!Settings::bSwitchTarget)
-			return tps->ProcessCameraCollision();
+		if (!Settings::bSwitchTarget) return tps->ProcessCameraCollision();
 
 		PlayerCharacter* player = PlayerCharacter::GetSingleton();
 		PlayerCamera* camera = (PlayerCamera*)tps->camera;
@@ -954,17 +958,14 @@ namespace Tralala
 				if (g_refTarget->movementCtrlNPC)
 				{
 					MovementControllerNPC* movementCtrl = g_refTarget->movementCtrlNPC;
-
 					BSFixedString intfc("IMovementSetGoal");
-
 					IMovementInterface* movementIntfc = movementCtrl->QueryMovementInterface(intfc);
+
 					if (movementIntfc)
 					{
 						IMovementSetGoal* setGoal = (IMovementSetGoal*)movementIntfc;
 						UInt32 unkVar = *(UInt32*)(setGoal + 0x6);
-
-						if(unkVar != 3)
-							setGoal->ClearPathingRequest();
+						if (unkVar != 3) setGoal->ClearPathingRequest();
 					}
 				}
 
@@ -973,7 +974,9 @@ namespace Tralala
 				NiPoint3 targetHeadPos;
 				bool targetHeadPosRet = false;
 				if (!player->GetTargetHeadNodePosition(&targetHeadPos, &targetHeadPosRet))
+				{
 					player->GetMarkerPosition(&targetHeadPos);
+				}
 
 				NiPoint3 headPos;
 				bool headPosRet = true;
@@ -1004,15 +1007,12 @@ namespace Tralala
 					}
 
 	#endif
-				
 					isPCCollided = true;
 				}
 
 				if (isPCCollided)
 				{
-					NiPoint3 offset(Settings::fHumanCamOffsetX, 
-						Settings::fHumanCamOffsetY, 
-						Settings::fHumanCamOffsetZ);
+					NiPoint3 offset(Settings::fHumanCamOffsetX, Settings::fHumanCamOffsetY, Settings::fHumanCamOffsetZ);
 					if (!headPosRet)
 					{
 						offset.x = Settings::fCreatureCamOffsetX;
@@ -1040,8 +1040,7 @@ namespace Tralala
 
 				if (!player->IsSneaking() && player->actorState.IsWeaponDrawn())
 				{
-					if (pcHeight <= 0.0f)
-						pcHeight = targetPos.z - player->pos.z;
+					if (pcHeight <= 0.0f) pcHeight = targetPos.z - player->pos.z;
 
 					targetPos.x = player->pos.x;
 					targetPos.y = player->pos.y;
@@ -1088,9 +1087,7 @@ namespace Tralala
 				if (abs(curDistance - distance) >= 10.0f)
 				{
 					float newFOV = roundf((atanf(Settings::f3rdZoom / distance) * 2.0f) * 180.0f / PI);
-					if (newFOV < 30.0f)
-						newFOV = 30.0f;
-
+					if (newFOV < 30.0f) newFOV = 30.0f;
 					SetZoom(newFOV);
 					curDistance = distance;
 				}
@@ -1113,21 +1110,18 @@ namespace Tralala
 					if (camera->IsInCameraView(&targetPos, PlayerCamera::KRotate_Stop))
 					{
 						constexpr float speed = 1.0f / 90.f;
-
 						diffAngleX = origDiffAngleX * speed * mult;
 						diffAngleZ = origDiffAngleZ * speed * mult;
 					}
 					else if (camera->IsInCameraView(&targetPos, PlayerCamera::kRotate_Slow))
 					{
 						constexpr float speed = 1.0f / 60.f;
-
 						diffAngleX = origDiffAngleX * speed * mult;
 						diffAngleZ = origDiffAngleZ * speed * mult;
 					}
 					else
 					{
 						constexpr float speed = 1.0f / 30.f;
-
 						diffAngleX = origDiffAngleX * speed * mult;
 						diffAngleZ = origDiffAngleZ * speed * mult;
 					}
@@ -1142,7 +1136,6 @@ namespace Tralala
 			}
 			else
 			{
-
 				NiPoint3 targetHeadPos;
 				bool targetHeadPosRet = true;
 				if (!g_refTarget->GetTargetHeadNodePosition(&targetHeadPos, &targetHeadPosRet))

--- a/resource.h
+++ b/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by AlternateConversationCamera.rc
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif


### PR DESCRIPTION
As described in my Nexus comment (https://forums.nexusmods.com/index.php?/topic/7149346-simple-face-to-face-conversation-kiwami-updated/page-67#entry80473098). Would be great to have this flag in to be able to ignore the HUD message positioning so it doesn't interfere with other UI mods.