### PR TITLE
Fix crash when ref target actor is removed during a conversation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1165,7 +1165,10 @@ namespace Tralala
 				Havok::hkpRootCdPoint resultInfo;
 				Actor* resultActor = nullptr;
 
-				if (camera->GetClosestPoint(g_refTarget->GetbhkWorldM(), &targetHeadPos, &resultPos, &resultInfo,
+				// Make sure the world is valid before testing - If an actor is deleted during a converstaion, the world
+				// can become null, causing a crash.
+				auto world = g_refTarget->GetbhkWorldM();
+				if (world && camera->GetClosestPoint(world, &targetHeadPos, &resultPos, &resultInfo,
 					&resultActor, 1.0f))
 				{
 	#if 0


### PR DESCRIPTION
When an actor is removed/deleted during a conversation, there appears to be 1 frame during which the target actor is still valid and being processed, but for which the bhkWorldM reference is not. Just adding an extra check to make sure the world is not null is all that is needed to fix this issue.